### PR TITLE
fix race condition between gc and process-packet

### DIFF
--- a/src/com/deercreeklabs/talk2/common.cljc
+++ b/src/com/deercreeklabs/talk2/common.cljc
@@ -207,8 +207,7 @@
                              bytes)
           {:keys [cb]} (@*rpc-id->info rpc-id)]
       (swap! *rpc-id->info dissoc rpc-id)
-      (if-not cb
-        (log/error (str "No callback found for rpc-id `" rpc-id "`."))
+      (when cb
         (cb ret)))))
 
 (defmethod <process-packet! :rpc-err-rsp
@@ -219,8 +218,7 @@
     (let [{:keys [rpc-id]} packet
           {:keys [cb]} (@*rpc-id->info rpc-id)]
       (swap! *rpc-id->info dissoc rpc-id)
-      (if-not cb
-        (log/error (str "No callback found for rpc-id `" rpc-id "`."))
+      (when cb
         (cb (ex-info (str "RPC failed. msg-type-name: `" msg-type-name "`. "
                           "msg-type-id: `" msg-type-id "`. "
                           "rpc-id: `" rpc-id "`.\n See peer log "


### PR DESCRIPTION
This isn't the main issue I was after but in trying to reproduce the main issue I stumbled upon a reliable reproduction of "No rpc found for id...". What I did was put a delay in an rpc handler server side so I had time to pause the javascript execution in the browser, wait for the timeout to pass, then resume the javascript. This error happened every time. I think what's happening is the gc loop quickly cleans up the rpc but in a race condition common/process-packet tries to process it but then there's no callback because the gc dissoced it from the atom already. This fix tracks garbage collected rpc's so you know not to log an error during the race condition and just drop it.