### PR TITLE
fail rpcs on client disconnect

### DIFF
--- a/src/com/deercreeklabs/talk2/client.cljc
+++ b/src/com/deercreeklabs/talk2/client.cljc
@@ -36,10 +36,11 @@
 
 (defn fail-rpcs! [{:keys [*rpc-id->info reason]}]
   (doseq [[rpc-id info] @*rpc-id->info]
-    (let [{:keys [cb] :or {cb (constantly nil)}} info]
-      (cb (ex-info
-            (str "RPC failed because " reason ".")
-            (u/sym-map rpc-id))))))
+    (let [{:keys [cb]} info]
+      (when (ifn? cb)
+        (cb (ex-info
+             (str "RPC failed because " reason ".")
+             (u/sym-map rpc-id)))))))
 
 (defn connect!
   [{:keys [*conn-info


### PR DESCRIPTION
My hypothesis is that with this change, instead of randomly seeing "RPC timed out" we will see "RPC failed because the client disconnected." If my laptop shutting theory is correct.